### PR TITLE
Add --insecure flag to skip server certificate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ history, so please use with care.
  - `--auth=basic` - enable HTTP Basic authentication.
  - `--basic-username=foo` - the username.
  - `--basic-password=bar` - the password.
-
+ - `--insecure` - For HTTPS connections, specify this flag to skip server certificate validation.
 
 ## Building from source
 
@@ -100,5 +100,5 @@ Copyright © Viktor Elofsson and contributors.
 Blaze is provided as-is under the MIT license. For more information see
 [LICENSE](https://github.com/vktr/blaze/blob/master/LICENSE).
 
- - For libcurl, see https://curl.haxx.se/docs/copyright.html 
+ - For libcurl, see https://curl.haxx.se/docs/copyright.html
  - For RapidJSON, see https://github.com/Tencent/rapidjson/blob/master/license.txt

--- a/src/blaze.cpp
+++ b/src/blaze.cpp
@@ -23,6 +23,7 @@ struct auth_options
     std::string type;
     std::string user;
     std::string pass;
+    bool insecure;
 };
 
 struct dump_options
@@ -77,6 +78,12 @@ bool get_or_post_data(
     curl_easy_setopt(crl, CURLOPT_URL,           url.c_str());
     curl_easy_setopt(crl, CURLOPT_WRITEFUNCTION, &write_data);
     curl_easy_setopt(crl, CURLOPT_WRITEDATA,     reinterpret_cast<void*>(data));
+
+    if (auth.insecure)
+    {
+        curl_easy_setopt(crl, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_easy_setopt(crl, CURLOPT_SSL_VERIFYHOST, 0);
+    }
 
     if (auth.type == "basic")
     {
@@ -397,6 +404,8 @@ int main(
             }
         }
     }
+
+    auth.insecure = cmdl["--insecure"];
 
     if (cmdl["--dump-mappings"])
     {


### PR DESCRIPTION
This pull request adds a `--insecure` flag to blaze that is analogous to the curl command's `--insecure` flag.