### PR TITLE
Improvements in Dockerfile and corrections in makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,13 @@ LABEL maintainer="norman@khine.net"
 
 WORKDIR /tmp
 
-RUN apk update \
-  && apk add --no-cache g++ gcc automake make autoconf libtool openssl-dev curl-dev git \
-  && git clone --recurse-submodules https://github.com/unidentifieddeveloper/blaze.git . \
-  && make
+RUN apk update
+
+RUN apk add --no-cache g++ gcc automake make autoconf libtool curl-dev git \
+
+RUN git clone --recurse-submodules https://github.com/unidentifieddeveloper/blaze.git . \
+
+RUN make
 
 # -- runtime context
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ WORKDIR /tmp
 
 RUN apk update
 
-RUN apk add --no-cache g++ gcc automake make autoconf libtool curl-dev git \
+RUN apk add --no-cache g++ gcc automake make autoconf libtool curl-dev git
 
-RUN git clone --recurse-submodules https://github.com/unidentifieddeveloper/blaze.git . \
+RUN git clone --recurse-submodules https://github.com/unidentifieddeveloper/blaze.git .
 
 RUN make
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPPFLAGS=--std=c++11 -O3 -DNDEBUG=1
+CPPFLAGS=--std=c++11 -mtune=native -O3 -DNDEBUG=1
 CXX=g++
 RM=rm -f
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CPPFLAGS=--std=c++11 -march=native -O3 -DNDEBUG=1
+CPPFLAGS=--std=c++11 -O3 -DNDEBUG=1
 CXX=g++
 RM=rm -f
 


### PR DESCRIPTION
### Improvements and corrections

1. Removed openssl-dev as it was causing dependency related issues and the image build process kept failing. 

2. Splitted a single shell command into multiple RUN operations to utilize container based caching. 

3. `-march=native` can generate code that may not run on processors of any other cpu-type. This was causing issues in our project where the project was built on a different machine and deployed on a different machine. `blaze` kept crashing with illegal instruction errors. 
This has been fixed by replacing `-march=native` with a more considerate alternative `-mtune=native` which will not use instructions that are not supported all cpu-types. 