### PR TITLE
Removed index _type attribute to support Elasticsearch 8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN apk update
 
 RUN apk add --no-cache g++ gcc automake make autoconf libtool curl-dev git
 
-RUN git clone --recurse-submodules https://github.com/unidentifieddeveloper/blaze.git .
+COPY vendor/ ./vendor
+COPY src/ ./src
+COPY Makefile .
 
 RUN make
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ cat dump.ndjson | parallel --pipe -l 50000 curl -s -H "Content-Type: application
  - `--size=<value>` - *(optional)* the size of the response (i.e, length of the `hits` array).
    Defaults to *5000*.
  - `--dump-mappings` - specify this flag to dump the index mappings instead of the source.
+ - `--dump-index-info` - specify this flag to dump the full index information (settings and mappings) instead of the source.
 
 #### Authentication
 

--- a/src/blaze.cpp
+++ b/src/blaze.cpp
@@ -135,14 +135,11 @@ void write_document(
     {
         auto meta_index      = rapidjson::Value(rapidjson::kObjectType);
         auto meta_index_id   = rapidjson::Value();
-        auto meta_index_type = rapidjson::Value();
         auto meta_object     = rapidjson::Value(rapidjson::kObjectType);
 
         meta_index_id.SetString(hit["_id"].GetString(), allocator);
-        meta_index_type.SetString(hit["_type"].GetString(), allocator);
 
         meta_index.AddMember("_id",   meta_index_id,   allocator);
-        meta_index.AddMember("_type", meta_index_type, allocator);
 
         meta_object.AddMember("index", meta_index, allocator);
 


### PR DESCRIPTION
- Removed _type from dump metadata (deprecated since 7.x https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html)
- Dockerfile now builds from source instead of cloning the git repo
- New argument `--dump-index-info` to get both mapping and settings for index